### PR TITLE
Add backup file before writing to share path

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ MEDIA=private
 - `persist`: After adding all of your information including files and directories
 to the local path, run this command to encrypt and move everything to your shared 
 path in cloud. The old version of encrypted information on shared path will be 
-**OVERWRITTEN**.
+kept as a backup.
 
 ```sh
 mysam.sh persist

--- a/mysam.sh
+++ b/mysam.sh
@@ -69,6 +69,8 @@ function toshare() {
     export PINENTRY_USER_DATA="USE_CURSES=1"
     gpg --verbose --symmetric "$TMP_PATH/$MEDIA.tar.gz"
 
+    # keep a backup of the old file
+    mv -v "$SHARED_PATH/$MEDIA.tar.gz.gpg" "$SHARED_PATH/$MEDIA-archived-$(date +'%Y%m%d-%H%M').tar.gz.gpg"
     mv -v "$TMP_PATH/$MEDIA.tar.gz.gpg" "$SHARED_PATH"
 }
 


### PR DESCRIPTION
Using a password manager, you might pick wrong password and you will write you archive with unknown password. In other words you will lose the data.

By this change we make a backup from old shared file. Keep in mind, time to time remove not needed backups to save the space in your cloud area.